### PR TITLE
Inconsistent character encoding for school name/title

### DIFF
--- a/src/EducAction/AdesBundle/Config.php
+++ b/src/EducAction/AdesBundle/Config.php
@@ -77,8 +77,8 @@ class Config{
             if(file_exists($fname)) {
                 require_once $fname;
                 self::$schoolConfig=array(
-                    "name"=>ECOLE,
-                    "title"=>TITRE
+                    "name"=>mb_convert_encoding(ECOLE, "utf8","latin1"),
+                    "title"=>mb_convert_encoding(TITRE, "utf8","latin1")
                 );
             } else {
                 self::$schoolConfig=array(

--- a/src/EducAction/AdesBundle/Controller/InstallController.php
+++ b/src/EducAction/AdesBundle/Controller/InstallController.php
@@ -151,8 +151,8 @@ EOF;
 		$file=fopen(Config::SchoolConfigFile(),"wt");
 		if($file){
 			fprintf($file, $format
-				, var_export($this->params->schoolname, true)
-				, var_export($this->params->title, true)
+				, mb_convert_encoding(var_export($this->params->schoolname, true), "latin1","utf8")
+				, mb_convert_encoding(var_export($this->params->title, true), "latin1","utf8")
 			);
 			fclose($file);
 			return true;


### PR DESCRIPTION
When a new version is pushed, it looks like the name of the school suffers from encoding error.

By logging in and re-editing the school name, it fixes it until the next version push.

~~To be confirmed~~ see bug identification below

# Test
* upon install, choose a name/title with accent
* **on a legacy page e.g. index.php, the name/title must be properly displayed**
* **on a new page e.g. backup, the name/title must be properly displayed**
* modify the name/title to something else with accent
* **on a legacy page e.g. index.php, the name/title must be properly displayed**
* **on a new page e.g. backup, the name/title must be properly displayed**

